### PR TITLE
TinCan Type attribute changed

### DIFF
--- a/datamodels/tincanlib.php
+++ b/datamodels/tincanlib.php
@@ -96,7 +96,7 @@ function scorm_get_tincan_manifest($blocks, $scoes) {
                     }
                 break;
                 case 'ACTIVITY':
-                	if (empty($course_id) && isset($block['attrs']['TYPE']) && $block['attrs']['TYPE'] == 'course') {
+                	if (empty($course_id) && isset($block['attrs']['TYPE']) && strpos($block['attrs']['TYPE'],'course') > 0) {
                 		
 	                    $org = $parent = array_pop($parents);
 	                    array_push($parents, $parent);


### PR DESCRIPTION
TinCan activity type attribute now contains a url
"http://adlnet.gov/expapi/activities/course" not just a type "course"
(when output from articulate / storyline 2 )
